### PR TITLE
Fix issue with double slashes in URL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 import type { LoadContext, Plugin } from "@docusaurus/types"
 import axios, { AxiosRequestConfig } from "axios"
-import { existsSync, mkdirSync, writeFileSync } from "fs"
-
-import { sync as delFile } from "rimraf"
+import { existsSync, writeFileSync, mkdirSync } from "fs"
 import { join } from "path"
-import milli from "pretty-ms"
+import { sync as delFile } from "rimraf"
 import picocolors from "picocolors"
+import milli from "pretty-ms"
 
 /**
  * The plugin's options.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import type { LoadContext, Plugin } from "@docusaurus/types"
 import axios, { AxiosRequestConfig } from "axios"
-import { existsSync, writeFileSync, mkdirSync } from "fs"
-import { join } from "path"
+import { existsSync, mkdirSync, writeFileSync } from "fs"
+
 import { sync as delFile } from "rimraf"
-import picocolors from "picocolors"
+import { join } from "path"
 import milli from "pretty-ms"
+import picocolors from "picocolors"
 
 /**
  * The plugin's options.
@@ -107,7 +108,7 @@ export default function pluginRemoteContent(
                 : ((await documents) as string[])
 
         for (const d of resolvedDocs) {
-            a.push({ url: `${sourceBaseUrl}/${d}`, identifier: d })
+            a.push({ url: `${sourceBaseUrl}${d}`, identifier: d })
         }
 
         return a

--- a/testsite/docusaurus.config.js
+++ b/testsite/docusaurus.config.js
@@ -132,5 +132,19 @@ module.exports = {
                 },
             },
         ],
+        [
+            require.resolve("../build/index.js"),
+            {
+                name: "github-labels",
+                id: "pathSlashesTest",
+                sourceBaseUrl:
+                    "https://api.github.com/repos/rdilweb/docusaurus-plugin-remote-content",
+                documents: ["labels"],
+                outDir: "docs/output-dir-testing/_data",
+                requestConfig: {
+                    responseType: "arraybuffer",
+                },
+            },
+        ],
     ],
 }


### PR DESCRIPTION
In `index.ts`, `sourceBaseUrl` gets a `"/"` added at the end if not already present, but in `findCollectables` the url is defined as `${sourceBaseUrl}/${d}`, causing a double slash in URLs.

The URLs in the current examples do not trigger an error when multiple forward slashes are present. For example, this is a valid URL: https://raw.githubusercontent.com/PowerShell/PowerShell/master////////////README.md

I added an example that does trigger an error using the GitHub API for the issue labels in this same repository: https://api.github.com/repos/rdilweb/docusaurus-plugin-remote-content/labels.

This also serves as a way to document how to use this plugin for fetching data from this API, as it requires `responseType: "arraybuffer"` in its config to work (or it's interpreted as a JSON array, which cannot be serialized to file using the current method).