### PR TITLE
testsite: README update

### DIFF
--- a/testsite/README.md
+++ b/testsite/README.md
@@ -11,7 +11,7 @@ yarn install
 ## Local Development
 
 ```console
-yarn start
+yarn testsite:start
 ```
 
 This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
@@ -19,7 +19,7 @@ This command starts a local development server and open up a browser window. Mos
 ## Build
 
 ```console
-yarn build
+yarn testsite:build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.


### PR DESCRIPTION
Updating commands in `testsite/README.md` as the current ones do not work.

As below, from `testsite/`:
```
$ yarn start
Usage Error: Couldn't find a script named "start".
> yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] <scriptName> ...
```
```
$ yarn testsite:start
[INFO] Starting the development server...
[SUCCESS] Docusaurus website is running at http://localhost:3000/.

✔ Client
  Compiled successfully in 2.87s

client (webpack 5.72.0) compiled successfully
```

The same for `build`:
```
$ yarn build
Usage Error: Couldn't find a script named "build".
> yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] <scriptName> ...
```

```
$yarn testsite:build
[INFO] [en] Creating an optimized production build...

✔ Client


✔ Server
  Compiled successfully in 19.96s


✔ Client


● Server █████████████████████████ cache (99%) shutdown IdleFileCachePlugin
 stored

[SUCCESS] Generated static files in build.
[INFO] Use `npm run serve` command to test your build locally.
```

(FWIW `yarn install` is ok)