### PR TITLE
README update: documents field example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The folder to emit the downloaded content to.
 
 The documents to fetch. Must be file names (e.g. end in `.md`)
 Following the previous example, if you had set `sourceBaseUrl` to https://example.com/content/,
-and wanted to fetch thing.md and hello.md, you would just set `documents` to `["hello", "thing"]`
+and wanted to fetch thing.md and hello.md, you would just set `documents` to `["hello.md", "thing.md"]`
 
 ### `performCleanup`
 


### PR DESCRIPTION
I was surprised when reading the README if there's some implicit mechanism to default files extension to some popular ones. It looks like it was just a typo in the example, as for

```
diff --git a/testsite/docusaurus.config.js b/testsite/docusaurus.config.js
index 599e213..e232beb 100644
--- a/testsite/docusaurus.config.js
+++ b/testsite/docusaurus.config.js
@@ -123,7 +123,7 @@ module.exports = {
                 id: "outputDirectoryTest",
                 sourceBaseUrl:
                     "https://raw.githubusercontent.com/PowerShell/PowerShell/master",
-                documents: ["README.md", "CODE_OF_CONDUCT.md"],
+                documents: ["README", "CODE_OF_CONDUCT"],
                 outDir: "docs/output-dir-testing",
                 requestConfig: {
                     headers: {
```
it fails to found files:
```
$ yarn testsite:start
[INFO] Starting the development server...
[ERROR] Error: Request failed with status code 404
```