### PR TITLE
docs: remove explicit v2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docusaurus-plugin-remote-content
 
-A Docusaurus v2 plugin that downloads content from remote sources.
+A Docusaurus plugin that downloads content from remote sources.
 
 With this plugin, you can write the Markdown for your content somewhere else, and use them on your Docusaurus site, without copying and pasting.
 


### PR DESCRIPTION
As of [v4.0.0](https://github.com/rdilweb/docusaurus-plugin-remote-content/releases/tag/v4.0.0), Docusaurus v3 is also supported. So it may be an idea to remove the v2 references? 

![image](https://github.com/rdilweb/docusaurus-plugin-remote-content/assets/2505178/d294dfbb-ef09-42ae-872f-43f2aec3babb)

